### PR TITLE
fix: Fix missing command on migration from klipper

### DIFF
--- a/docs/Migrating_from_Klipper.md
+++ b/docs/Migrating_from_Klipper.md
@@ -44,6 +44,7 @@ cd ~/klipper
 git remote add kalico https://github.com/KalicoCrew/kalico.git
 git checkout -b upstream-main origin/master
 git branch -D master
+git fetch kalico main
 git checkout -b main kalico/main
 sudo systemctl restart klipper
 sudo systemctl restart moonraker


### PR DESCRIPTION
Before being able to switch to kalico/main branch, git fetch is required to download the refs.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
